### PR TITLE
[New Segment] - add prompt segment for nodenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The segments that are currently available are:
     * `node_version` - Show the version number of the installed Node.js.
     * `nodeenv` - [nodeenv](https://github.com/ekalinin/nodeenv) prompt for displaying node version and environment name.
     * `nvm` - Show the version of Node that is currently active, if it differs from the version used by NVM
+    * [`nodenv`](#nodenv) - Node environment information using `nodenv` (if one is active).
 * **PHP Segments:**
     * `php_version` - Show the current PHP version.
     * `laravel_version` - Show the current Laravel version.
@@ -577,6 +578,19 @@ Variable | Default Value | Description |
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
 |`P9K_RBENV_PROMPT_ALWAYS_SHOW`|`false`|Set to true if you wish to show the rbenv segment even if the current Ruby version is the same as the global Ruby version|
+
+##### nodenv
+
+This segment shows the version of Node being used when using `nodenv` to change your current Node stack.
+
+It figures out the version being used by taking the output of the `nodenv version-name` command.
+
+* If `nodenv` is not in $PATH, nothing will be shown.
+* By default, if the current local Node version is the same as the global Node version, nothing will be shown. See the configuration variable, below, to modify this behavior.
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+|`P9K_NODENV_PROMPT_ALWAYS_SHOW`|`false`|Set to true if you wish to show the nodenv segment even if the current Node version is the same as the global Node version|
 
 ##### pyenv
 

--- a/segments/nodenv.p9k
+++ b/segments/nodenv.p9k
@@ -1,0 +1,41 @@
+# vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+################################################################
+# @title powerlevel9k Segment - Node Environment
+# @source [powerlevel9k](https://github.com/bhilburn/powerlevel9k)
+##
+
+(){
+  # Set the right locale to protect special characters
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  ################################################################
+  # Register segment
+  # Parameters:
+  #   segment_name  context  background  foreground  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
+  #                                                                                                                      
+  p9k::register_segment "NODENV" "" "green" "${DEFAULT_COLOR}"  ''  $'\uE847 '  $'\uF219 '  '\u'$CODEPOINT_OF_OCTICONS_NODE' '  $'\uF219 '
+
+  ################################################################
+  # Register segment default values
+  p9k::set_default P9K_NODENV_PROMPT_ALWAYS_SHOW false
+}
+
+################################################################
+# @description
+#   Display the current nodenv information.
+##
+# @args
+#   $1 string Alignment - left | right
+#   $2 integer Segment index
+#   $3 boolean Whether the segment should be joined
+##
+prompt_nodenv() {
+  if [[ -n "${NODENV_VERSION}" ]]; then
+    p9k::prepare_segment "$0" "" $1 "$2" $3 "${NODENV_VERSION}"
+  elif [ ${commands[nodenv]} ]; then
+    local nodenv_version_name="$(nodenv version-name)"
+    local nodenv_global="$(nodenv global)"
+    if [[ "${nodenv_version_name}" != "${nodenv_global}" || "${P9K_NODENV_PROMPT_ALWAYS_SHOW}" == "true" ]]; then
+      p9k::prepare_segment "$0" "" $1 "$2" $3 "${nodenv_version_name}"
+    fi
+  fi
+}

--- a/test/segments/nodenv.spec
+++ b/test/segments/nodenv.spec
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+#vim:ft=zsh ts=2 sw=2 sts=2 et fenc=utf-8
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+function setUp() {
+  export TERM="xterm-256color"
+
+  P9K_HOME=$(pwd)
+  ### Test specific
+  # Create default folder and git init it.
+  FOLDER=/tmp/powerlevel9k-test/nodenv-test
+  mkdir -p "${FOLDER}/bin"
+  OLD_PATH=$PATH
+  PATH=${FOLDER}/bin:$PATH
+  cd $FOLDER
+  # Load Powerlevel9k
+  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source ${P9K_HOME}/segments/nodenv.p9k
+}
+
+function tearDown() {
+  # Restore old path
+  PATH="${OLD_PATH}"
+  # Go back to powerlevel9k folder
+  cd "${P9K_HOME}"
+  # Remove eventually created test-specific folder
+  rm -fr "${FOLDER}"
+  # At least remove test folder completely
+  rm -fr /tmp/powerlevel9k-test
+}
+
+function testNodenvSegmentPrintsNothingIfNodenvIsNotAvailable() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(nodenv custom_world)
+  local P9K_CUSTOM_WORLD='echo world'
+
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+}
+
+function testNodenvSegmentPrintsNothingWhenOnDefaultVersion() {
+  local -a P9K_LEFT_PROMPT_ELEMENTS
+  P9K_LEFT_PROMPT_ELEMENTS=(nodenv custom_world)
+  local P9K_CUSTOM_WORLD='echo world'
+
+  function nodenv_version() {
+    [[ ${1} == 'current' ]] && echo 'v4.6.0' || echo 'v4.6.0'
+  }
+
+  assertEquals "%K{015} %F{000}world %k%F{015}%f " "$(__p9k_build_left_prompt)"
+}
+
+source shunit2/shunit2


### PR DESCRIPTION
#### Description
- Adds a prompt segment for [`nodenv`](https://github.com/nodenv/nodenv)
- Copied from existing [`rbenv`](https://github.com/bhilburn/powerlevel9k/blob/next/segments/rbenv.p9k) segment

#### Questions
Please let me know whether specs are sufficient, copied from [nvm segment spec](https://github.com/bhilburn/powerlevel9k/blob/next/test/segments/nvm.spec) with some removed due to differences in the way they work.

#### Screenshot
![image](https://user-images.githubusercontent.com/5386965/50744632-fb1f0380-1278-11e9-9353-29de8ded95c7.png)
