### PR TITLE
 [Bugfix]  Pid fix

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -101,7 +101,7 @@ function __p9k_detect_terminal() {
       fi
       local pid=$$ termtest=''
       while true; do
-        if test "$pid" = "1" -o "$pid" = ""; then
+        if test "$pid" = "1" -o "$pid" = "" -o ! -d /proc/${pid}; then
           __P9K_TERMINAL="unknown"
           return
         fi


### PR DESCRIPTION
When started in the tty, powerline9k tries to open the stat file of the
`login` process. Because the `login` process belongs to root, it's
existence is hidden from non-privileged users. This will result in an
error like
`__p9k_detect_terminal:27: no such file or directory: /proc/3434/stat`.

Like #1336, this error appears to be ultimately harmless, but never the less annoying.

Signed-off-by: Hal Gentz <zegentzy@protonmail.com>