### PR TITLE
[Bugfix] Make prompt_rvm list gemset

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1347,7 +1347,7 @@ prompt_rspec_stats() {
 # Segment to display Ruby Version Manager information
 prompt_rvm() {
   if [ $commands[rvm-prompt] ]; then
-    local version_and_gemset=${$(rvm-prompt v p)/ruby-}
+    local version_and_gemset=${$(rvm-prompt v p g)/ruby-}
 
     if [[ -n "$version_and_gemset" ]]; then
       "$1_prompt_segment" "$0" "$2" "240" "$DEFAULT_COLOR" "$version_and_gemset" 'RUBY_ICON'

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1347,7 +1347,7 @@ prompt_rspec_stats() {
 # Segment to display Ruby Version Manager information
 prompt_rvm() {
   if [ $commands[rvm-prompt] ]; then
-    local version_and_gemset=${$(rvm-prompt v p g)/ruby-}
+    local version_and_gemset=$(rvm-prompt v p g)
 
     if [[ -n "$version_and_gemset" ]]; then
       "$1_prompt_segment" "$0" "$2" "240" "$DEFAULT_COLOR" "$version_and_gemset" 'RUBY_ICON'


### PR DESCRIPTION
The RVM Prompt segment doesn't display the used gemset, only the used ruby version.

The [documentation for rvm-prompt](https://rvm.io/workflow/prompt) says that
- `v` returns the version (e.g. `2.6.0`)
- `p` returns the patchlevel (e.g. `-rc1`)
- `g` returns the gemset (e.g. `@foo`)

So 
- `rvm-prompt v p` (current master) would return `2.6.0-rc1`
- we should be using `rvm-prompt v p g` which would return `2.6.0-rc1@foo`

Also we don't need to strip a `ruby-` from the output string. That's the interpreter identifier (for MRI) that would be included with the `i` flag.