### PR TITLE
Use $CONDA_PROMPT_MODIFIER if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ The segments that are currently available are:
 ##### anaconda
 
 This segment shows your active anaconda environment. It relies on either the
-`CONDA_ENV_PATH` or the `CONDA_PREFIX` (depending on the `conda` version)
-environment variable to be set which happens when you properly `source
-activate` an environment.
+`CONDA_PROMPT_MODIFIER`, `CONDA_ENV_PATH`, or `CONDA_PREFIX` (depending on the
+`conda` version) environment variable to be set which happens when you properly
+`source activate` an environment.
 
 Special configuration variables:
 

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -299,14 +299,22 @@ right_prompt_segment() {
 ################################################################
 # Anaconda Environment
 prompt_anaconda() {
-  # Depending on the conda version, either might be set. This
-  # variant works even if both are set.
-  local _path=$CONDA_ENV_PATH$CONDA_PREFIX
-  if ! [ -z "$_path" ]; then
-    # config - can be overwritten in users' zshrc file.
-    set_default POWERLEVEL9K_ANACONDA_LEFT_DELIMITER "("
-    set_default POWERLEVEL9K_ANACONDA_RIGHT_DELIMITER ")"
-    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$POWERLEVEL9K_ANACONDA_LEFT_DELIMITER$(basename $_path)$POWERLEVEL9K_ANACONDA_RIGHT_DELIMITER" 'PYTHON_ICON'
+  local modifier
+  if [ -n "$CONDA_PROMPT_MODIFIER" ]; then
+    modifier="$CONDA_PROMPT_MODIFIER"
+  else
+    # Depending on the conda version, either might be set. This
+    # variant works even if both are set.
+    local _path=$CONDA_ENV_PATH$CONDA_PREFIX
+    if ! [ -z "$_path" ]; then
+      # config - can be overwritten in users' zshrc file.
+      set_default POWERLEVEL9K_ANACONDA_LEFT_DELIMITER "("
+      set_default POWERLEVEL9K_ANACONDA_RIGHT_DELIMITER ")"
+      modifier="$POWERLEVEL9K_ANACONDA_LEFT_DELIMITER$(basename $_path)$POWERLEVEL9K_ANACONDA_RIGHT_DELIMITER"
+    fi
+  fi
+  if [ -n "$modifier" ]; then
+    "$1_prompt_segment" "$0" "$2" "blue" "$DEFAULT_COLOR" "$modifier" 'PYTHON_ICON'
   fi
 }
 

--- a/test/segments/anaconda.spec
+++ b/test/segments/anaconda.spec
@@ -66,4 +66,19 @@ function testAnacondaSegmentWorks() {
     assertEquals "%K{004} %F{000}icon-here %F{000}(tmptest) %k%F{004}%f " "$(build_left_prompt)"
 }
 
+function testAnacondaSegmentWorksIfCondaPromptModifierIsSet() {
+    local -a POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
+    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(anaconda)
+    local POWERLEVEL9K_PYTHON_ICON="icon-here"
+
+    # Load Powerlevel9k
+    source powerlevel9k.zsh-theme
+
+    local CONDA_PROMPT_MODIFIER="(modifier)"
+    local CONDA_ENV_PATH=/tmp
+    local CONDA_PREFIX="test"
+
+    assertEquals "%K{004} %F{000}icon-here %F{000}(modifier) %k%F{004}%f " "$(build_left_prompt)"
+}
+
 source shunit2/shunit2


### PR DESCRIPTION
On a default install of Anaconda, it installs to ~/anaconda3 but `conda env list` claims the name of the environment is `base`, not `anaconda3`. The environment variable has the correct name.